### PR TITLE
fix: nodejs server certs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,10 @@ services:
     ports:
       - 3000:3000
     working_dir: /usr/src/app
+    volumes:
+      - ./certs/server.crt:/usr/src/app/certs/server.crt
+      - ./certs/server.key:/usr/src/app/certs/server.key
+      - ./certs/ca.crt:/usr/src/app/certs/ca.crt
 
   nginx:
     image: nginx


### PR DESCRIPTION
I added server cert references in the nodejs project:

```
version: "3"

services:
  node_basic:
    build:
      context: node-server
    ports:
      - 3000:3000
    working_dir: /usr/src/app
    volumes:
      - ./certs/server.crt:/usr/src/app/certs/server.crt
      - ./certs/server.key:/usr/src/app/certs/server.key
      - ./certs/ca.crt:/usr/src/app/certs/ca.crt

  nginx:
    image: nginx
    ports:
      - "443:443"
      - "80:80"
    volumes:
      - ./nginx-server/proxy.conf:/etc/nginx/conf.d/default.conf
      - ./certs/server.crt:/etc/ssl/server.crt
      - ./certs/server.key:/etc/ssl/server.key
      - ./certs/ca.crt:/etc/nginx/client_certs/ca.crt

```
